### PR TITLE
added 'response_type' as a parameter for instagram auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist
 /share
 /project/.sbtserver
 /content-raw/*.zip
+*.keystore
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/dataplug-instagram/conf/silhouette.conf
+++ b/dataplug-instagram/conf/silhouette.conf
@@ -48,4 +48,7 @@ silhouette {
   instagram.clientSecret = ""
   instagram.clientSecret = ${?INSTAGRAM_CLIENT_SECRET}
   instagram.scope = "basic"
+  instagram.authorizationParams {
+    response_type = "code"
+  }
 }


### PR DESCRIPTION
added 'response_type' as a parameter for instagram since it's required by the API