### PR TITLE
Fix spotify selecting playlists

### DIFF
--- a/dataplug-spotify/app/org/hatdex/dataplugSpotify/apiInterfaces/SpotifyUserPlaylistsList.scala
+++ b/dataplug-spotify/app/org/hatdex/dataplugSpotify/apiInterfaces/SpotifyUserPlaylistsList.scala
@@ -47,7 +47,7 @@ class SpotifyUserPlaylistsList @Inject() (
               pathParameters = pathParameters,
               storageParameters = Some(Map("playlistName" -> playlist.name)))))
 
-          ApiEndpointVariantChoice(playlist.id, playlist.name, active = false, variant)
+          ApiEndpointVariantChoice(playlist.id, playlist.name, active = true, variant)
         }
       }
     }.getOrElse(Seq())


### PR DESCRIPTION
Fix spotify selecting playlists. All playlists are now selected by default