### PR TITLE
removed location from media model

### DIFF
--- a/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/models/InstagramMedia.scala
+++ b/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/models/InstagramMedia.scala
@@ -20,8 +20,7 @@ case class InstagramMedia(
     `type`: String,
     filter: String,
     tags: List[String],
-    id: String,
-    location: Option[InstagramLocation])
+    id: String)
 
 case class InstagramCount(count: Long)
 


### PR DESCRIPTION
Location was Optional. That was correct. There were instances with `"location": null`. I dunno if play handles that automatically. Also the Location Model itself, states latitude AND longitude are NON optional. Again I found cases that location had only an `id` and nothing more. 