### PR TITLE
fixed duplicate data between posts and feed

### DIFF
--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
@@ -155,7 +155,7 @@ object FacebookFeedInterface {
     "/me/feed",
     ApiEndpointMethod.Get("Get"),
     Map(),
-    Map("limit" -> "500", "fields" -> ("id,attachments,caption,created_time,description,from,full_picture,icon,link," +
+    Map("limit" -> "250", "fields" -> ("id,attachments,caption,created_time,description,from,full_picture,icon,link," +
       "is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags")),
     Map(),
     Some(Map()))

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
@@ -155,9 +155,8 @@ object FacebookPostsInterface {
     "/me/posts",
     ApiEndpointMethod.Get("Get"),
     Map(),
-    Map("limit" -> "500", "fields" -> ("id,attachments,caption,created_time,description,from,full_picture,icon,link," +
-      "is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags")),
+    Map("limit" -> "250", "fields" -> ("id,attachments,caption,created_time,description,from,full_picture,icon,link," +
+      "is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags")),
     Map(),
     Some(Map()))
 }
-

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
@@ -66,10 +66,10 @@ class FacebookProfileCheck @Inject() (
       Some(""), Some(""),
       Some(FacebookPostsInterface.defaultApiEndpoint))
 
-    val userLikesVariant = ApiEndpointVariant(
-      ApiEndpoint("likes/pages", "User's likes on Facebook", None),
-      Some(""), Some(""),
-      Some(FacebookUserLikesInterface.defaultApiEndpoint))
+    //    val userLikesVariant = ApiEndpointVariant(
+    //      ApiEndpoint("likes/pages", "User's likes on Facebook", None),
+    //      Some(""), Some(""),
+    //      Some(FacebookUserLikesInterface.defaultApiEndpoint))
 
     val eventsVariant = ApiEndpointVariant(
       ApiEndpoint("events", "Facebook events the user has been invited to", None),
@@ -81,7 +81,7 @@ class FacebookProfileCheck @Inject() (
       ApiEndpointVariantChoice("profile/picture", "User's Facebook profile picture", active = true, profilePictureVariant),
       ApiEndpointVariantChoice("feed", "User's Facebook posts feed", active = true, feedVariant),
       ApiEndpointVariantChoice("posts", "User's own Facebook posts", active = true, postsVariant),
-      ApiEndpointVariantChoice("likes/pages", "User's likes on Facebook", active = true, userLikesVariant),
+      //      ApiEndpointVariantChoice("likes/pages", "User's likes on Facebook", active = true, userLikesVariant),
       ApiEndpointVariantChoice("events", "Facebook events the user has been invited to", active = true, eventsVariant))
 
     choices

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/modules/FacebookPlugModule.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/modules/FacebookPlugModule.scala
@@ -66,16 +66,14 @@ class FacebookPlugModule extends AbstractModule with ScalaModule with AkkaGuiceS
     facebookProfilePictureInterface: FacebookProfilePictureInterface,
     facebookEventInterface: FacebookEventInterface,
     facebookFeedInterface: FacebookFeedInterface,
-    facebookPostsInterface: FacebookPostsInterface,
-    facebookUserLikesInterface: FacebookUserLikesInterface): DataPlugRegistry = {
+    facebookPostsInterface: FacebookPostsInterface): DataPlugRegistry = {
 
     DataPlugRegistry(Seq(
       facebookProfileInterface,
       facebookProfilePictureInterface,
       facebookEventInterface,
       facebookFeedInterface,
-      facebookPostsInterface,
-      facebookUserLikesInterface))
+      facebookPostsInterface))
   }
 
   @Provides

--- a/dataplug-facebook/conf/evolutions/dataplug.sql
+++ b/dataplug-facebook/conf/evolutions/dataplug.sql
@@ -66,7 +66,7 @@ VALUES
   ('posts', 'User''s own Facebook posts', 'sequence')
 ON CONFLICT (name) DO NOTHING;
 
---changeset dataplugFacebook:addMoreIsSphericalToPosts
+-- --changeset dataplugFacebook:addMoreIsSphericalToPosts
 
 UPDATE dataplug_user
 SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
@@ -80,8 +80,9 @@ WHERE dataplug_user.dataplug_endpoint = 'feed';
 
 --changeset dataplugFacebook:ResetFeedEndpoint
 
-UPDATE dataplug_user
+UPDATE dataplug_user u1
 SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
-WHERE dataplug_user.phata = (SELECT phata FROM dataplug_user as U WHERE U.dataplug_endpoint = 'posts' AND U.active = true AND dataplug_user.phata = U.phata) AND dataplug_user.dataplug_endpoint = 'feed';
+FROM dataplug_user u2
+WHERE u1.dataplug_endpoint = 'feed' AND u2.dataplug_endpoint = 'posts' AND u1.phata = u2.phata;
 
 

--- a/dataplug-facebook/conf/evolutions/dataplug.sql
+++ b/dataplug-facebook/conf/evolutions/dataplug.sql
@@ -81,7 +81,7 @@ WHERE dataplug_user.dataplug_endpoint = 'feed';
 --changeset dataplugFacebook:ResetFeedEndpoint
 
 UPDATE dataplug_user u1
-SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
+SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
 FROM dataplug_user u2
 WHERE u1.dataplug_endpoint = 'feed' AND u2.dataplug_endpoint = 'posts' AND u1.phata = u2.phata;
 

--- a/dataplug-facebook/conf/evolutions/dataplug.sql
+++ b/dataplug-facebook/conf/evolutions/dataplug.sql
@@ -75,7 +75,13 @@ WHERE dataplug_user.dataplug_endpoint = 'posts';
 --changeset dataplugFacebook:changeLimitToFeed
 
 UPDATE dataplug_user
-SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
+SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters,limit}', '"250"')
 WHERE dataplug_user.dataplug_endpoint = 'feed';
+
+--changeset dataplugFacebook:ResetFeedEndpoint
+
+UPDATE dataplug_user
+SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
+WHERE dataplug_user.phata = (SELECT phata FROM dataplug_user as U WHERE U.dataplug_endpoint = 'posts' AND U.active = true AND dataplug_user.phata = U.phata) AND dataplug_user.dataplug_endpoint = 'feed';
 
 

--- a/dataplug-facebook/conf/evolutions/dataplug.sql
+++ b/dataplug-facebook/conf/evolutions/dataplug.sql
@@ -59,7 +59,6 @@ UPDATE dataplug_user
 SET endpoint_configuration = jsonb_set(endpoint_configuration, '{url}', '"https://graph.facebook.com/v5.0"')
 WHERE dataplug_user.endpoint_configuration -> 'url' = '"https://graph.facebook.com/v2.10"'
 
-
 --changeset dataplugFacebook:endpointsInsertUserPosts context:data
 
 INSERT INTO dataplug_endpoint (name, description, details)
@@ -67,5 +66,16 @@ VALUES
   ('posts', 'User''s own Facebook posts', 'sequence')
 ON CONFLICT (name) DO NOTHING;
 
+--changeset dataplugFacebook:addMoreIsSphericalToPosts
+
+UPDATE dataplug_user
+SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,is_spherical,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
+WHERE dataplug_user.dataplug_endpoint = 'posts';
+
+--changeset dataplugFacebook:changeLimitToFeed
+
+UPDATE dataplug_user
+SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters}', '{"fields":"id,attachments,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags","limit":"250"}')
+WHERE dataplug_user.dataplug_endpoint = 'feed';
 
 


### PR DESCRIPTION
Added one field in posts, `is_spherical`. This field indicates if the video is spherical or not. By default in all of my posts is to false, even if there is no video attached. As facebook's documentation doesn't state if it's optional or not, the only way to know is to test it. In my testing I always have this value, even in my posts from 2007. You can check out the field here: https://developers.facebook.com/docs/graph-api/reference/page-post

There is an issue that I cannot understand though.I have 4078 posts and 3505 feed items. I don't know how this is possible. I did get warnings that some times, items from `feed` could not be parsed and the plug was parsing them one by one. That might explain the why. I dunno what is the value that's causing the issue, again it requires more testing since Facebook doesn't help in this at all.

Issue where `posts` and `feed` endpoints are shown twice in database doesn't happen to me. Fresh db with hat that didn't have any Facebook data. I am wondering if one of my evolutions caused this issue.

Also because I got more errors from Facebook indicating the requests were timing out on Facebook side, I lowered the limit to `250`. Added the evolutions to update the limit as well