### PR TITLE
Implemented disconnect flow logic

### DIFF
--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
@@ -21,7 +21,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.FacebookEvent
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
@@ -21,7 +21,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.FacebookPost
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
@@ -11,7 +11,7 @@ package com.hubofallthings.dataplugFacebook.apiInterfaces
 import com.google.inject.Inject
 import com.hubofallthings.dataplug.apiInterfaces.DataPlugContentUploader
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import com.hubofallthings.dataplug.actors.Errors.{ SourceApiCommunicationException, SourceAuthenticationException }
 import com.hubofallthings.dataplug.apiInterfaces.authProviders.{ OAuth2TokenHelper, RequestAuthenticatorOAuth2 }
 import com.hubofallthings.dataplug.apiInterfaces.models.{ ApiEndpointCall, ApiEndpointMethod, DataPlugNotableShareRequest }

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
@@ -20,7 +20,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.FacebookPost
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json.{ JsArray, JsObject, JsValue }
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
@@ -16,7 +16,7 @@ import com.hubofallthings.dataplug.apiInterfaces.models.{ ApiEndpoint, ApiEndpoi
 import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.Mailer
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json.JsValue
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
@@ -20,7 +20,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.FacebookProfile
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
@@ -20,7 +20,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.FacebookProfilePicture
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
@@ -21,7 +21,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugFacebook.models.{ FacebookPost, FacebookUserLikes }
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/models/FacebookProfile.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/models/FacebookProfile.scala
@@ -16,9 +16,11 @@ case class FacebookProfile(
     email: Option[String],
     first_name: String,
     last_name: String,
+    full_name: Option[String],
     gender: Option[String], //need extra permissions
     name: String,
     age_range: Option[String],
+    profile_pic: Option[String],
     link: Option[String])
 
 case class FacebookBasicUser(

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/modules/FacebookPlugModule.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/modules/FacebookPlugModule.scala
@@ -11,16 +11,17 @@ package com.hubofallthings.dataplugFacebook.modules
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
 import com.hubofallthings.dataplug.dao.{ DataPlugEndpointDAO, DataPlugEndpointDAOImpl, DataPlugSharedNotableDAO, DataPlugSharedNotableDAOImpl }
 import com.hubofallthings.dataplug.services.{ DataPlugEndpointService, DataPlugEndpointServiceImpl, DataPlugNotablesService, DataPlugNotablesServiceImpl, StartupService, StartupServiceImpl }
-import com.hubofallthings.dataplugFacebook.apiInterfaces.{ FacebookEventInterface, FacebookFeedInterface, FacebookPostsInterface, FacebookProfileCheck, FacebookProfileInterface, FacebookProfilePictureInterface, FacebookUserLikesInterface }
+import com.hubofallthings.dataplugFacebook.apiInterfaces.{ FacebookEventInterface, FacebookFeedInterface, FacebookPostsInterface, FacebookProfileCheck, FacebookProfileInterface, FacebookProfilePictureInterface }
+import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
 import com.mohiva.play.silhouette.api.Provider
 import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.providers._
-import com.mohiva.play.silhouette.impl.providers.oauth2.FacebookProvider
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.codingwell.scalaguice.ScalaModule
@@ -47,6 +48,7 @@ class FacebookPlugModule extends AbstractModule with ScalaModule with AkkaGuiceS
     bind[DataPlugNotablesService].to[DataPlugNotablesServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[FacebookProvider]
 
     //    bindActorFactory[InjectedHatClientActor, InjectedHatClientActor.Factory]
     bindActor[DataPlugManagerActor]("dataplug-manager")

--- a/dataplug-fitbit/app/com/hubofallthings/dataplugFitbit/Module.scala
+++ b/dataplug-fitbit/app/com/hubofallthings/dataplugFitbit/Module.scala
@@ -13,6 +13,7 @@ import com.hubofallthings.dataplugFitbit.apiInterfaces.authProviders.FitbitProvi
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -45,6 +46,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[FitbitProvider]
 
     //    bindActorFactory[InjectedHatClientActor, InjectedHatClientActor.Factory]
     bindActor[DataPlugManagerActor]("dataplug-manager")

--- a/dataplug-fitbit/app/com/hubofallthings/dataplugFitbit/apiInterfaces/authProviders/FitbitProvider.scala
+++ b/dataplug-fitbit/app/com/hubofallthings/dataplugFitbit/apiInterfaces/authProviders/FitbitProvider.scala
@@ -14,6 +14,7 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import FitbitProvider._
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import play.api.http.HeaderNames._
 import play.api.libs.json.{ JsArray, JsValue }
 
@@ -24,7 +25,7 @@ import scala.concurrent.Future
  *
  * @see https://dev.fitbit.com/docs/oauth2/
  */
-trait BaseFitbitProvider extends OAuth2Provider {
+trait BaseFitbitProvider extends HatOAuth2Provider {
 
   /**
    * The content type to parse a profile from.

--- a/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/Module.scala
+++ b/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/Module.scala
@@ -11,6 +11,7 @@ package com.hubofallthings.dataplugCalendar
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -19,8 +20,8 @@ import com.hubofallthings.dataplug.services.{ DataPlugEndpointService, DataPlugE
 import com.hubofallthings.dataplugCalendar.apiInterfaces.{ GoogleCalendarEventsInterface, GoogleCalendarList, GoogleCalendarsInterface }
 import com.mohiva.play.silhouette.api.Provider
 import com.mohiva.play.silhouette.api.util.HTTPLayer
-import com.mohiva.play.silhouette.impl.providers._
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.mohiva.play.silhouette.impl.providers.{ OAuth2Settings, SocialProviderRegistry, SocialStateHandler }
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders._
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.codingwell.scalaguice.ScalaModule
@@ -45,6 +46,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[GoogleProvider]
 
     bindActor[DataPlugManagerActor]("dataplug-manager")
   }

--- a/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarEventsInterface.scala
+++ b/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarEventsInterface.scala
@@ -13,7 +13,7 @@ import akka.actor.Scheduler
 import akka.util.Timeout
 import com.google.inject.Inject
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders._
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplug.actors.Errors.SourceDataProcessingException
 import com.hubofallthings.dataplug.apiInterfaces.DataPlugEndpointInterface

--- a/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarList.scala
+++ b/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarList.scala
@@ -16,7 +16,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.Mailer
 import com.hubofallthings.dataplugCalendar.models.GoogleCalendar
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json.JsValue
 import play.api.libs.ws.WSClient

--- a/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarsInterface.scala
+++ b/dataplug-gcalendar/app/com/hubofallthings/dataplugCalendar/apiInterfaces/GoogleCalendarsInterface.scala
@@ -20,7 +20,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransformations, Mailer }
 import com.hubofallthings.dataplugCalendar.models.GoogleCalendar
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders.GoogleProvider
 import play.api.Logger
 import play.api.libs.json.{ JsArray, JsObject, JsValue }
 import play.api.libs.ws.WSClient

--- a/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/Module.scala
+++ b/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/Module.scala
@@ -11,6 +11,7 @@ package com.hubofallthings.dataplugInstagram
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -45,6 +46,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[InstagramProvider]
 
     //    bindActorFactory[InjectedHatClientActor, InjectedHatClientActor.Factory]
     bindActor[DataPlugManagerActor]("dataplug-manager")

--- a/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/apiInterfaces/authProviders/InstagramProvider.scala
+++ b/dataplug-instagram/app/com/hubofallthings/dataplugInstagram/apiInterfaces/authProviders/InstagramProvider.scala
@@ -12,6 +12,7 @@ import com.mohiva.play.silhouette.api.util.{ ExtractableRequest, HTTPLayer }
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import InstagramProvider._
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import play.api.libs.json._
 import play.api.mvc.Result
 
@@ -22,7 +23,7 @@ import scala.concurrent.Future
  *
  * @see https://docs.yapily.com/?version=latest
  */
-trait BaseInstagramProvider extends OAuth2Provider {
+trait BaseInstagramProvider extends HatOAuth2Provider {
 
   /**
    * The content type to parse a profile from.
@@ -69,9 +70,9 @@ trait BaseInstagramProvider extends OAuth2Provider {
       .get().flatMap { response =>
 
         val json = response.json
-        (json \ "access_token").asOpt[String] match {
-          case Some(longLivedAccessToken) => Future.successful(authInfo.copy(accessToken = longLivedAccessToken))
-          case None                       => throw new ProfileRetrievalException(SpecifiedProfileError.format(id, 401, "Cannot refresh instagram token", ""))
+        json.asOpt[OAuth2Info] match {
+          case Some(instagramOAuthInfo) => Future.successful(instagramOAuthInfo)
+          case None                     => throw new ProfileRetrievalException(SpecifiedProfileError.format(id, 401, "Cannot refresh instagram token", ""))
         }
       }
   }
@@ -182,4 +183,3 @@ object InstagramProvider {
   val ID = "instagram"
   val API = "https://graph.instagram.com/me"
 }
-

--- a/dataplug-monzo/app/com/hubofallthings/dataplugMonzo/Module.scala
+++ b/dataplug-monzo/app/com/hubofallthings/dataplugMonzo/Module.scala
@@ -10,6 +10,7 @@ package com.hubofallthings.dataplugMonzo
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -44,6 +45,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[MonzoProvider]
 
     bindActor[DataPlugManagerActor]("dataplug-manager")
   }

--- a/dataplug-monzo/app/com/hubofallthings/dataplugMonzo/apiInterfaces/authProviders/MonzoProvider.scala
+++ b/dataplug-monzo/app/com/hubofallthings/dataplugMonzo/apiInterfaces/authProviders/MonzoProvider.scala
@@ -13,6 +13,7 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import MonzoProvider._
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import play.api.http.HeaderNames._
 import play.api.libs.json.{ JsObject, JsValue }
 
@@ -23,7 +24,7 @@ import scala.concurrent.Future
  *
  * @see https://monzo.com/docs/#authentication
  */
-trait BaseMonzoProvider extends OAuth2Provider {
+trait BaseMonzoProvider extends HatOAuth2Provider {
 
   /**
    * The content type to parse a profile from.

--- a/dataplug-monzo/conf/application.dev.conf
+++ b/dataplug-monzo/conf/application.dev.conf
@@ -4,6 +4,6 @@ include "application.conf"
 
 service.scheme = "https://"
 service.address = "dataplug.hat.org:9443"
-service.secure = false
+service.secure = true
 
 play.mailer.mock = true

--- a/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/Module.scala
+++ b/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/Module.scala
@@ -11,6 +11,7 @@ package com.hubofallthings.dataplugSpotify
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -45,6 +46,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[SpotifyProvider]
 
     //    bindActorFactory[InjectedHatClientActor, InjectedHatClientActor.Factory]
     bindActor[DataPlugManagerActor]("dataplug-manager")

--- a/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/apiInterfaces/SpotifyUserPlaylistsList.scala
+++ b/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/apiInterfaces/SpotifyUserPlaylistsList.scala
@@ -16,7 +16,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.Mailer
 import com.hubofallthings.dataplugSpotify.models.SpotifyUsersPlaylist
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders._
 import play.api.Logger
 import play.api.libs.json.JsValue
 import play.api.libs.ws.WSClient

--- a/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/apiInterfaces/authProviders/SpotifyProvider.scala
+++ b/dataplug-spotify/app/com/hubofallthings/dataplugSpotify/apiInterfaces/authProviders/SpotifyProvider.scala
@@ -14,6 +14,7 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import SpotifyProvider._
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import play.api.http.HeaderNames._
 import play.api.libs.json.{ JsArray, JsValue }
 
@@ -24,7 +25,7 @@ import scala.concurrent.Future
  *
  * @see https://dev.fitbit.com/docs/oauth2/
  */
-trait BaseSpotifyProvider extends OAuth2Provider {
+trait BaseSpotifyProvider extends HatOAuth2Provider {
 
   /**
    * The content type to parse a profile from.

--- a/dataplug-starling/app/com/hubofallthings/dataplugStarling/Module.scala
+++ b/dataplug-starling/app/com/hubofallthings/dataplugStarling/Module.scala
@@ -10,6 +10,7 @@ package com.hubofallthings.dataplugStarling
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -44,6 +45,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[StarlingProvider]
 
     //    bindActorFactory[InjectedHatClientActor, InjectedHatClientActor.Factory]
     bindActor[DataPlugManagerActor]("dataplug-manager")

--- a/dataplug-starling/app/com/hubofallthings/dataplugStarling/apiInterfaces/authProviders/StarlingProvider.scala
+++ b/dataplug-starling/app/com/hubofallthings/dataplugStarling/apiInterfaces/authProviders/StarlingProvider.scala
@@ -14,6 +14,7 @@ import com.mohiva.play.silhouette.api.util.HTTPLayer
 import com.mohiva.play.silhouette.impl.exceptions.ProfileRetrievalException
 import com.mohiva.play.silhouette.impl.providers._
 import StarlingProvider._
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import play.api.http.HeaderNames._
 import play.api.libs.json.{ JsArray, JsValue }
 
@@ -24,7 +25,7 @@ import scala.concurrent.Future
  *
  * @see https://dev.fitbit.com/docs/oauth2/
  */
-trait BaseStarlingProvider extends OAuth2Provider {
+trait BaseStarlingProvider extends HatOAuth2Provider {
 
   /**
    * The content type to parse a profile from.

--- a/dataplug-uber/app/com/hubofallthings/dataplugUber/Module.scala
+++ b/dataplug-uber/app/com/hubofallthings/dataplugUber/Module.scala
@@ -11,6 +11,7 @@ package com.hubofallthings.dataplugUber
 import akka.actor.{ ActorSystem, Scheduler }
 import com.google.inject.{ AbstractModule, Provides }
 import com.hubofallthings.dataplug.actors.DataPlugManagerActor
+import com.hubofallthings.dataplug.apiInterfaces.authProviders.HatOAuth2Provider
 import com.hubofallthings.dataplug.apiInterfaces.{ DataPlugOptionsCollector, DataPlugOptionsCollectorRegistry, DataPlugRegistry }
 import com.hubofallthings.dataplug.controllers.{ DataPlugViewSet, DataPlugViewSetDefault }
 import com.hubofallthings.dataplug.dal.SchemaMigrationImpl
@@ -45,6 +46,7 @@ class Module extends AbstractModule with ScalaModule with AkkaGuiceSupport {
     bind[DataPlugEndpointService].to[DataPlugEndpointServiceImpl]
 
     bind[DataPlugViewSet].to[DataPlugViewSetDefault]
+    bind[HatOAuth2Provider].to[UberProvider]
 
     bindActor[DataPlugManagerActor]("dataplug-manager")
   }

--- a/dataplug-uber/conf/application.dev.conf
+++ b/dataplug-uber/conf/application.dev.conf
@@ -4,6 +4,6 @@ include "application.conf"
 
 service.scheme = "https://"
 service.address = "dataplug.hat.org:9443"
-service.secure = false
+service.secure = true
 
 play.mailer.mock = true

--- a/dataplug/app/com/hubofallthings/dataplug/apiInterfaces/authProviders/HatOAuth2Provider.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/apiInterfaces/authProviders/HatOAuth2Provider.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2016-2020 Dataswift Ltd - All Rights Reserved
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Written by Marios Tsekis <marios.tsekis@dataswift.io>, 04 2020
+ */
+
+package com.hubofallthings.dataplug.apiInterfaces.authProviders
+
+import akka.Done
+import com.mohiva.play.silhouette.impl.providers.OAuth2Provider
+
+import scala.concurrent.Future
+
+trait HatOAuth2Provider extends OAuth2Provider {
+  def disconnect(phata: String, userId: String): Future[Done] = Future.successful(Done)
+}

--- a/dataplug/app/com/hubofallthings/dataplug/controllers/DataPlugViewSet.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/controllers/DataPlugViewSet.scala
@@ -28,6 +28,8 @@ trait DataPlugViewSet {
 
   def indexRedirect: Call
 
+  def disconnectRedirect: Call
+
   def signupComplete(
     socialProviderRegistry: SocialProviderRegistry,
     endpointVariants: Option[Seq[ApiEndpointVariantChoice]])(implicit user: User, request: RequestHeader, messages: Messages): Html

--- a/dataplug/app/com/hubofallthings/dataplug/controllers/DataPlugViewSetDefault.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/controllers/DataPlugViewSetDefault.scala
@@ -34,6 +34,9 @@ class DataPlugViewSetDefault extends DataPlugViewSet {
   def indexRedirect: Call =
     com.hubofallthings.dataplug.controllers.routes.Application.index()
 
+  def disconnectRedirect: Call =
+    com.hubofallthings.dataplug.controllers.routes.Application.disconnect()
+
   def signupComplete(
     socialProviderRegistry: SocialProviderRegistry,
     endpointVariants: Option[Seq[ApiEndpointVariantChoice]])(implicit user: User, request: RequestHeader, messages: Messages): Html = {
@@ -47,6 +50,7 @@ class DataPlugViewSetDefault extends DataPlugViewSet {
     chooseVariants: Boolean)(implicit user: User, request: RequestHeader, messages: Messages): Html = {
     dataplugViews.html.disconnect(socialProviderRegistry, endpointVariants,
       request.session.get("redirect").getOrElse(defaultRedirect),
+      disconnectRedirect,
       chooseVariants)
   }
 

--- a/dataplug/app/com/hubofallthings/dataplug/controllers/HatLoginController.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/controllers/HatLoginController.scala
@@ -17,7 +17,6 @@ import com.mohiva.play.silhouette.api.{ LoginEvent, Silhouette }
 import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
 import com.mohiva.play.silhouette.impl.providers.SocialProviderRegistry
 import com.nimbusds.jwt.SignedJWT
-import com.hubofallthings.dataplug.controllers.routes
 import play.api.Configuration
 import play.api.data.Forms._
 import org.joda.time.DateTime

--- a/dataplug/app/com/hubofallthings/dataplug/dao/UserDAO.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/dao/UserDAO.scala
@@ -8,6 +8,7 @@
 
 package com.hubofallthings.dataplug.dao
 
+import akka.Done
 import com.hubofallthings.dataplug.models.User
 import com.mohiva.play.silhouette.api.LoginInfo
 
@@ -41,4 +42,13 @@ trait UserDAO {
    * @param linkedLoginInfo The login info of the user to link.
    */
   def link(mainLoginInfo: LoginInfo, linkedLoginInfo: LoginInfo): Future[Unit]
+
+  /**
+   * Deletes user from relevant user tables.
+   *
+   * @param phata The phata of the user to delete.
+   * @param userId The userId of user to delete.
+   * @return Done if success.
+   */
+  def delete(phata: String, userId: String): Future[Done]
 }

--- a/dataplug/app/com/hubofallthings/dataplug/services/UserService.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/services/UserService.scala
@@ -8,6 +8,7 @@
 
 package com.hubofallthings.dataplug.services
 
+import akka.Done
 import com.hubofallthings.dataplug.models.User
 import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.services.IdentityService
@@ -46,5 +47,20 @@ trait UserService extends IdentityService[User] {
    */
   def save(profile: CommonSocialProfile): Future[User]
 
+  /**
+   * Links two user accounts together (e.g. multi-account login with social credentials)
+   *
+   * @param mainUser The login info of the main user.
+   * @param linkedUser The login info of the user to link.
+   */
   def link(mainUser: User, linkedUser: User): Future[Unit]
+
+  /**
+   * Deletes user from relevant user tables.
+   *
+   * @param phata The phata of the user to delete.
+   * @param userId The userId of user to delete.
+   * @return Done if success.
+   */
+  def delete(phata: String, userId: String): Future[Done]
 }

--- a/dataplug/app/com/hubofallthings/dataplug/services/UserServiceImpl.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/services/UserServiceImpl.scala
@@ -8,6 +8,7 @@
 
 package com.hubofallthings.dataplug.services
 
+import akka.Done
 import com.hubofallthings.dataplug.dao.UserDAO
 import com.hubofallthings.dataplug.models.User
 import javax.inject.Inject
@@ -62,7 +63,24 @@ class UserServiceImpl @Inject() (userDAO: UserDAO) extends UserService {
     }
   }
 
+  /**
+   * Links two user accounts together (e.g. multi-account login with social credentials)
+   *
+   * @param mainUser The login info of the main user.
+   * @param linkedUser The login info of the user to link.
+   */
   def link(mainUser: User, linkedUser: User) = {
     userDAO.link(mainUser.loginInfo, linkedUser.loginInfo)
+  }
+
+  /**
+   * Deletes user from relevant user tables.
+   *
+   * @param phata The phata of the user to delete.
+   * @param userId The userId of user to delete.
+   * @return Done if success.
+   */
+  def delete(phata: String, userId: String): Future[Done] = {
+    userDAO.delete(phata, userId)
   }
 }

--- a/dataplug/app/com/hubofallthings/dataplug/views/disconnect.scala.html
+++ b/dataplug/app/com/hubofallthings/dataplug/views/disconnect.scala.html
@@ -1,12 +1,11 @@
 @import com.hubofallthings.dataplug.apiInterfaces.models.ApiEndpointVariantChoice
 @import com.mohiva.play.silhouette.impl.providers.SocialProviderRegistry
 @import com.hubofallthings.dataplug.models.User
-@import com.hubofallthings.dataplug.controllers.routes
 
-@import com.hubofallthings.dataplug.models.User
 @(socialProviders: SocialProviderRegistry,
         endpointVariants: Option[Seq[ApiEndpointVariantChoice]],
         redirect: String,
+        disconnectUrl: Call,
         chooseVariants: Boolean = false)(implicit user: User, request: RequestHeader, messages: Messages)
 
 @import views.html.b3.vertical.fieldConstructor
@@ -29,7 +28,7 @@
                 <div class="complete-instructions">
                     @Messages("disconnect.note")
                 </div>
-                <a class="btn btn-block btn-dataplug" href="@routes.Application.disconnect()">
+                <a class="btn btn-block btn-dataplug" href="@disconnectUrl">
                     @Messages("disconnect.button")
                 </a>
             }.getOrElse {
@@ -39,9 +38,6 @@
                 <div class="complete-instructions">
                     @Messages("disconnect.noteDisconnected")
                 </div>
-                <a class="btn btn-block btn-dataplug" href="@routes.Application.index()">
-                    @Messages("disconnect.reconnectButton")
-                </a>
             }
             <a class="btn btn-block btn-dataplug" id="rumpel-link" href="@redirect">
             @Messages("button.rumpel")

--- a/dataplug/test/com/hubofallthings/dataplug/testkit/TestModule.scala
+++ b/dataplug/test/com/hubofallthings/dataplug/testkit/TestModule.scala
@@ -22,7 +22,7 @@ import com.mohiva.play.silhouette.api.{Environment, EventBus}
 import com.mohiva.play.silhouette.crypto.{JcaCookieSigner, JcaCookieSignerSettings, JcaCrypter, JcaCrypterSettings}
 import com.mohiva.play.silhouette.impl.authenticators.{CookieAuthenticator, CookieAuthenticatorService, CookieAuthenticatorSettings}
 import com.mohiva.play.silhouette.impl.providers._
-import com.mohiva.play.silhouette.impl.providers.oauth2.GoogleProvider
+import com.hubofallthings.dataplugCalendar.apiInterfaces.authProviders._
 import com.mohiva.play.silhouette.impl.providers.oauth2.state.{CookieStateProvider, CookieStateSettings}
 import com.mohiva.play.silhouette.impl.util.{DefaultFingerprintGenerator, SecureRandomIDGenerator}
 import com.mohiva.play.silhouette.password.BCryptPasswordHasher


### PR DESCRIPTION
* Changes to the core plug to fix disconnect not killing actors 
* Changes to enable OAuthProviders to handle the disconnect in the 3rd party side if needed
* Updated all the plugs, except twitter, to support the new disconnect flow
* Updated some settings to smooth the flow while running locally


### Context for extra brevity: 

This is a refactoring to enable the plugs to disconnect from a 3rd party service such as Facebook. Some 3rd party services have started to impose a disconnect AND a deauthorize endpoint. The main task was to provide a universal way for all of the plugs to be able to disconnect or deauthorize from the 3rd party. This is achieved in 2 different parts:

##### Normal disconnect 
The aim for this is to be used from all the plugs and delete all the user's data, such as the tokens, from the local database. The code can be found in `Application.scala` of the core plug as `disconnect`. Plugs are able to `override` this function to implement their own logic if needed.

##### Advanced disconnect
The sole necessity of having a second part of the disconnect logic is to provide the Data Plug to  specify custom actions to be executed. Such actions are delete Data Plug specific tables from the database or make extra API requests to the 3rd party service. The reason this is an another file is simply to keep the separation of concerns. I felt the best place for such code will be the custom `OAuthProvider` classes implemented in some Data Plugs as it specifically handles the authorisation of a Data Plug, I felt it's appropriate to handle the disconnect/deauthorize logic as well. Of course it can be overridden by the Data Plugs to provide a custom implementation. Most of the currently implemented Data Plugs will not need this.